### PR TITLE
assign status code to variable

### DIFF
--- a/sdk/concretes/Traits/ResponseManagement.php
+++ b/sdk/concretes/Traits/ResponseManagement.php
@@ -44,7 +44,7 @@ trait ResponseManagement
         $contents = json_decode($responseCurl->getBody()->getContents());
 
         //Dealing with the response possibilities
-        switch ($responseCurl->getStatusCode()) {
+        switch ($code = $responseCurl->getStatusCode()) {
             case 200:
                 //verify if response has more than one entry
                 if (array_key_exists("entries", $contents)) {


### PR DESCRIPTION
some cases' return object referenced an undefined variable, thus returning an empty code